### PR TITLE
Add media type icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .DS_Store
+.vscode
 .editorconfig
 .eslintrc.js
 .scss-lint.yml
 
 /bower_components/
 /node_modules/
+
+package-lock.json*

--- a/src/js/iconify.js
+++ b/src/js/iconify.js
@@ -38,7 +38,7 @@ function init () {
 }
 
 function createElement (item) {
-	return toElement(`<button class="${CSS_CLASS_PREFIX}-icon ${CSS_CLASS_PREFIX}-icon-state-${String(item.messageCode).toLowerCase()}" ${ATTR_CONTENT_ID}="${item[DATA_ID_PROPERTY]}" ${ATTR_ISO_LANG}="${item[DATA_LANG_PROPERTY] || DEFAULT_LANGUAGE}" ${ATTR_CONTENT_TYPE}="${item.type}" ${ATTR_SYNDICATED}="true" ${ATTR_TRACKABLE}="${ATTR_TRACKABLE_VALUE}" data-message-code="${item.messageCode}" type="button"></button>`);
+	return toElement(`<button class="${CSS_CLASS_PREFIX}-icon ${CSS_CLASS_PREFIX}-icon-state-${String(item.messageCode).toLowerCase()} ${CSS_CLASS_PREFIX}-icon--${String(item.type).toLowerCase()}" ${ATTR_CONTENT_ID}="${item[DATA_ID_PROPERTY]}" ${ATTR_ISO_LANG}="${item[DATA_LANG_PROPERTY] || DEFAULT_LANGUAGE}" ${ATTR_CONTENT_TYPE}="${item.type}" ${ATTR_SYNDICATED}="true" ${ATTR_TRACKABLE}="${ATTR_TRACKABLE_VALUE}" data-message-code="${item.messageCode}" type="button"></button>`);
 }
 
 function findElementToSyndicate (el) {

--- a/src/js/modal-download.js
+++ b/src/js/modal-download.js
@@ -164,7 +164,7 @@ function createElement (item) {
 		trackableValueSaveForLater += '-downloads-page';
 	}
 	else if (location.pathname.includes('/save')) {
-//		trackableValueDownloadItem = 'download-saved-item';
+		// trackableValueDownloadItem = 'download-saved-item';
 		trackableValueDownloadItem = '';
 	}
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -54,6 +54,17 @@
 	background-color: rgba(getColor('mandarin'), 0.85);
 	}
 
+.n-syndication-icon--video {
+	@include oIconsGetIcon('video', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
+	background-color: rgba(getColor('jade'), 0.85); // TODO: don't always make them green!
+}
+
+.n-syndication-icon--podcast {
+	@include oIconsGetIcon('podcast', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
+	background-color: rgba(getColor('jade'), 0.85); // TODO: don't always make them green!
+}
+
+
 
 .n-syndication-icon-state-maintenance {
 	background-image: none;


### PR DESCRIPTION
Adds podcast and video icons to respective content types‘ syndication buttons

**TODO:** currently all the icons will be green, need to sort out when they should be amber/red etc and what should take precedence

<img width="288" alt="screenshot 2017-12-01 18 11 21" src="https://user-images.githubusercontent.com/11544418/33496993-3ff963c0-d6c4-11e7-8a8e-ecbd4a9fa094.png">
<img width="1206" alt="screenshot 2017-12-01 18 11 38" src="https://user-images.githubusercontent.com/11544418/33496996-421f3a4e-d6c4-11e7-8853-da90dd51e125.png">
