### PR TITLE
Missing overlay dependency

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,3 +1,4 @@
+@import 'o-overlay/main';
 
 .n-syndication-icon {
 	@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);


### PR DESCRIPTION
In n-ui, this was relying on another module to import o-overlay. Silly.