### PR TITLE
Republishing nav item - only clone the link inside target element, not all children

### DIFF
--- a/src/js/navigation.js
+++ b/src/js/navigation.js
@@ -22,9 +22,15 @@ function insertUserNavItem (user) {
 	return ({ selectorContainer, selectorInsertionPoint, selectorLink }) => {
 		const elCt = $(selectorContainer);
 
-		const elInsertionPoint = elCt.querySelector(selectorInsertionPoint).parentElement;
+		const navLink = elCt.querySelector(selectorInsertionPoint);
+		if (!navLink)
+			return;
 
-		const elNavItem = elInsertionPoint.cloneNode(true);
+		const elInsertionPoint = navLink.parentElement;
+
+		const elNavItem = elInsertionPoint.cloneNode();
+		const navLinkCopy = navLink.cloneNode();
+		elNavItem.appendChild(navLinkCopy);
 
 		elNavItem.setAttribute('data-trackable', 'syndication');
 


### PR DESCRIPTION
Fixes an issue where if the cloned nav item contains a tooltip, that was being cloned as well.

![screen shot 2018-06-20 at 14 08 43](https://user-images.githubusercontent.com/471250/41665434-df7cf942-749f-11e8-96b8-ed28b59d22ca.png)


 🐿 v2.9.0