### PR TITLE
Being more defensive when finding a container for a nav item

### DIFF
--- a/src/js/navigation.js
+++ b/src/js/navigation.js
@@ -21,6 +21,9 @@ function init (user) {
 function insertUserNavItem (user) {
 	return ({ selectorContainer, selectorInsertionPoint, selectorLink }) => {
 		const elCt = $(selectorContainer);
+		if (!elCt) {
+			return;
+		}
 
 		const navLink = elCt.querySelector(selectorInsertionPoint);
 		if (!navLink) {


### PR DESCRIPTION
When a nav container wasn't found, we were getting errors that prevented the rest of the JavaScript from running.

Have yet to figure out why this has all of a sudden become a problem though.