### PR TITLE
Fix spanish modal

### DIFF
--- a/src/js/republishing.js
+++ b/src/js/republishing.js
@@ -29,7 +29,7 @@ function _init (flags, user) {
 			window.republishingInitData = function () {};
 		}
 
-		initDataStore(flags, user, window.republishingInitData());
+		initDataStore(user, window.republishingInitData());
 
 		initDownloadModal(user);
 	}

--- a/src/js/republishing.js
+++ b/src/js/republishing.js
@@ -31,7 +31,7 @@ function _init (flags, user) {
 
 		initDataStore(flags, user, window.republishingInitData());
 
-		initDownloadModal(flags, user);
+		initDownloadModal(user);
 	}
 
 	window.getRepublishingUser = () => user;


### PR DESCRIPTION
During a refactor, some function calls hadn't been updated to remove some parameters, causing some issues when trying to trigger the modal for downloading Spanish content.