### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "main.js",
   "description": "Implementation for the syndication indicator, for users who subscribe to the new FT syndication platform",
   "devDependencies": {
-    "@financial-times/n-gage": "3.4.0",
+    "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-heroku-tools": "^7.3.0",
     "autoprefixer": "^6.3.6",
     "babel-core": "^6.25.0",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.