### PR TITLE
Ensure the republishing button gets added even if menu isn't there

### DIFF
--- a/src/js/navigation.js
+++ b/src/js/navigation.js
@@ -2,62 +2,75 @@
 
 import {$, broadcast} from 'n-ui-foundations';
 
-function init (user) {
-	const insertNavItem = insertUserNavItem(user);
-
-	insertNavItem({
-		selectorContainer: '#o-header-nav-desktop',
-		selectorInsertionPoint: '[data-trackable="Account Settings"]',
-		selectorLink: '.o-header__nav-link'
+function buildNavItem (user) {
+	const elNavItemLink = document.createElement('a');
+	elNavItemLink.classList.add('o-header__nav-link');
+	elNavItemLink.classList.add('n-syndication-republishing');
+	elNavItemLink.setAttribute('data-trackable', 'Republishing');
+	elNavItemLink.setAttribute('href', '/republishing/contract');
+	elNavItemLink.textContent = 'Republishing';
+	elNavItemLink.addEventListener('click', (evt) => {
+		broadcast('oTracking.event', {
+			category: 'syndication',
+			action: 'Republishing',
+			contractID: user.contract_id,
+			product: 'syndication',
+			referrer: location.href,
+			url: evt.target.href || evt.target.getAttribute('href')
+		});
 	});
 
-	insertNavItem({
-		selectorContainer: '#o-header-drawer',
-		selectorInsertionPoint: '[data-trackable="Portfolio"]',
-		selectorLink: '.o-header__drawer-menu-link'
-	});
+	const elNavItem = document.createElement('li');
+	elNavItem.classList.add('o-header__nav-item');
+	elNavItem.setAttribute('data-trackable', 'syndication');
+	elNavItem.appendChild(elNavItemLink);
+
+	return elNavItem;
 }
 
-function insertUserNavItem (user) {
-	return ({selectorContainer, selectorInsertionPoint, selectorLink}) => {
-		const elCt = $(selectorContainer);
-		if (!elCt) {
-			return;
-		}
+function insertDesktopNavItem (user) {
+	const elCt = $('#o-header-nav-desktop');
+	if (!elCt) {
+		return;
+	}
 
-		const navLink = elCt.querySelector(selectorInsertionPoint);
-		if (!navLink) {
-			return;
-		}
+	const container = elCt.querySelector('.o-header__container');
+	if (!container) {
+		return;
+	}
 
-		const elInsertionPoint = navLink.parentElement;
+	let userNav = container.querySelector('[data-trackable="user-nav"]');
+	if( !userNav ) {
+		userNav = document.createElement('ul');
+		userNav.classList.add('o-header__nav-list');
+		userNav.classList.add('o-header__nav-list--right');
+		userNav.setAttribute('data-trackable', 'user-nav');
+		container.appendChild(userNav);
+	}
 
-		const elNavItem = elInsertionPoint.cloneNode();
-		const navLinkCopy = navLink.cloneNode();
-		elNavItem.appendChild(navLinkCopy);
+	const elNavItem = buildNavItem(user);
+	userNav.appendChild(elNavItem);
+}
 
-		elNavItem.setAttribute('data-trackable', 'syndication');
+function insertDrawerNavItem (user) {
+	const elCt = $('#o-header-drawer');
+	if (!elCt) {
+		return;
+	}
 
-		const elNavItemLink = elNavItem.querySelector(selectorLink);
+	const navLink = elCt.querySelector('[data-trackable="Portfolio"]');
+	if (!navLink) {
+		return;
+	}
 
-		elNavItemLink.classList.add('n-syndication-republishing');
-		elNavItemLink.setAttribute('data-trackable', 'Republishing');
-		elNavItemLink.setAttribute('href', '/republishing/contract');
-		elNavItemLink.textContent = 'Republishing';
+	const elNavItem = buildNavItem(user);
+	const elInsertionPoint = navLink.parentElement;
+	elInsertionPoint.insertAdjacentElement('afterend', elNavItem);
+}
 
-		elInsertionPoint.insertAdjacentElement('afterend', elNavItem);
-
-		elNavItemLink.addEventListener('click', (evt) => {
-			broadcast('oTracking.event', {
-				category: 'syndication',
-				action: 'Republishing',
-				contractID: user.contract_id,
-				product: 'syndication',
-				referrer: location.href,
-				url: evt.target.href || evt.target.getAttribute('href')
-			});
-		});
-	};
+function init (user) {
+	insertDesktopNavItem(user);
+	insertDrawerNavItem(user);
 }
 
 export {


### PR DESCRIPTION
Fixes #57 

Looks like a complete re-write, but basically it's just 
- moving existing code around a lot
- using `document.createElement` instead of `Node.cloneNode`
- creating the user-nav if it isn't present

Not great, as I don't really like all this dynamically creating elements in JS stuff (means styles/classes etc need to be kept updated in both in HTML and JS), but hopefully it's a slight improvement. Anyway, it means we can go ahead with the AB test referenced in #57 (I have tested it works locally)

 🐿 v2.12.4