### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Run the (incomplete) test suite with
 $ make test
 ```
 
+Verify that the Sass can compile by running 
+
+```sh
+$ npx sass ./test/main.scss --load-path=./bower_components/
+```
+
 ### Developing with a next app
 
 The best way to develop with your changes on the site is to use [`bower link`](https://bower.io/docs/api/#link) in a running app. (If using `n-ui` to build you'll need to [set the `NEXT_APP_SHELL=local` variable](https://github.com/Financial-Times/n-ui#testing-in-an-app))

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "test/*"
   ],
   "dependencies": {
-    "n-ui-foundations": "^3.2.0",
+    "n-ui-foundations": "4.0.0-beta.2",
     "next-session-client": "^2.3.5",
     "o-buttons": "^6.0.2",
     "o-overlay": "^3.0.0",
@@ -38,6 +38,7 @@
     "o-viewport": "^4.0.0",
     "o-visual-effects": "^3.0.0",
     "o-overlay": "^3.0.0",
-    "o-tracking": "^2.0.3"
+    "o-tracking": "^2.0.3",
+    "n-ui-foundations": "4.0.0-beta.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,20 +25,5 @@
     "o-tracking": "^2.0.3",
     "superstore": "^2.1.0",
     "o-visual-effects": "^3.0.0"
-  },
-  "resolutions": {
-    "ftdomdelegate": "^4.0.0",
-    "o-buttons": "^6.0.2",
-    "o-colors": "^5.0.0",
-    "o-grid": "^5.0.0",
-    "o-icons": "^6.0.0",
-    "o-normalise": "^2.0.0",
-    "o-typography": "^6.0.0",
-    "o-fonts": "^4.0.0",
-    "o-viewport": "^4.0.0",
-    "o-visual-effects": "^3.0.0",
-    "o-overlay": "^3.0.0",
-    "o-tracking": "^2.0.3",
-    "n-ui-foundations": "4.0.0-beta.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,14 +18,26 @@
     "test/*"
   ],
   "dependencies": {
-    "n-ui-foundations": "^3.0.0-beta",
-    "next-session-client": "^2.3.3",
-    "o-buttons": ">=4.0.0 <6",
-    "o-overlay": "^2.0.0",
-    "o-tracking": "^1.1.8",
-    "superstore": "^2.1.0"
+    "n-ui-foundations": "^3.2.0",
+    "next-session-client": "^2.3.5",
+    "o-buttons": "^6.0.2",
+    "o-overlay": "^3.0.0",
+    "o-tracking": "^2.0.3",
+    "superstore": "^2.1.0",
+    "o-visual-effects": "^3.0.0"
   },
   "resolutions": {
-    "ftdomdelegate": "^3.0.0"
+    "ftdomdelegate": "^4.0.0",
+    "o-buttons": "^6.0.2",
+    "o-colors": "^5.0.0",
+    "o-grid": "^5.0.0",
+    "o-icons": "^6.0.0",
+    "o-normalise": "^2.0.0",
+    "o-typography": "^6.0.0",
+    "o-fonts": "^4.0.0",
+    "o-viewport": "^4.0.0",
+    "o-visual-effects": "^3.0.0",
+    "o-overlay": "^3.0.0",
+    "o-tracking": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "main.js",
   "description": "Implementation for the syndication indicator, for users who subscribe to the new FT syndication platform",
   "devDependencies": {
-    "@financial-times/n-gage": "^3.7.1",
+    "@financial-times/n-gage": "3.12.0",
     "@financial-times/n-heroku-tools": "^8.0.0",
     "autoprefixer": "^6.3.6",
     "babel-core": "^6.25.0",

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,8 +1,17 @@
-@import 'o-overlay/main';
+@import "o-buttons/main";
+@import "o-colors/main";
+@import "o-overlay/main";
+@import "o-visual-effects/main";
+
+$system-code: "n-syndication";
 
 .n-syndication-icon {
-	@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
-	background-color: rgba(getColor('slate'), 0.55);
+	@include oIconsContent(
+		$icon-name: "cross",
+		$color: oColorsByName("white"),
+		$size: 20
+	);
+	background-color: rgba(oColorsByName("slate"), 0.55);
 	border-color: transparent;
 	border-radius: 20px;
 	border-width: 0;
@@ -12,53 +21,68 @@
 	margin-right: 2px;
 	vertical-align: text-top;
 	width: 20px;
-	}
+}
 
 .n-syndication-icon.n-syndication-icon-state-no,
 .n-syndication-icon.n-syndication-icon-state-verify,
 .n-syndication-icon.n-syndication-icon-state-withcontributorpayment,
 .n-syndication-icon.n-syndication-icon-state-yes {
 	vertical-align: text-top;
-	}
+}
 
 .n-syndication-icon-state-msg_4000,
 .n-syndication-icon-state-msg_4050,
 .n-syndication-icon-state-msg_5000,
 .n-syndication-icon-state-msg_5100,
 .n-syndication-icon-state-no {
-	@include oIconsGetIcon('cross', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
-	background-color: rgba(getColor('claret'), 0.85);
-	}
+	@include oIconsContent(
+		$icon-name: "cross",
+		$color: oColorsByName("white"),
+		$size: 20
+	);
+	background-color: rgba(oColorsByName("claret"), 0.85);
+}
 
 .n-syndication-icon-state-msg_2000,
 .n-syndication-icon-state-msg_2100,
 .n-syndication-icon-state-msg_4100,
 .n-syndication-icon-state-msg_4300,
 .n-syndication-icon-state-yes {
-	@include oIconsGetIcon('tick', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
-	background-color: rgba(getColor('jade'), 0.85);
-	}
+	@include oIconsContent(
+		$icon-name: "tick",
+		$color: oColorsByName("white"),
+		$size: 20
+	);
+	background-color: rgba(oColorsByName("jade"), 0.85);
+}
 
 .n-syndication-icon-state-msg_2300,
 .n-syndication-icon-state-msg_2320,
 .n-syndication-icon-state-msg_2340,
 .n-syndication-icon-state-withcontributorpayment {
-	@include oIconsGetIcon('dollar', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
-	background-color: rgba(getColor('jade'), 0.85);
-	}
+	@include oIconsContent(
+		$icon-name: "dollar",
+		$color: oColorsByName("white"),
+		$size: 20
+	);
+	background-color: rgba(oColorsByName("jade"), 0.85);
+}
 
 .n-syndication-icon-state-msg_2200,
 .n-syndication-icon-state-msg_4200,
 .n-syndication-icon-state-msg_4250,
 .n-syndication-icon-state-verify {
-	@include oIconsGetIcon('minus', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
-	background-color: rgba(getColor('mandarin'), 0.85);
-	}
-
+	@include oIconsContent(
+		$icon-name: "minus",
+		$color: oColorsByName("white"),
+		$size: 20
+	);
+	background-color: rgba(oColorsByName("mandarin"), 0.85);
+}
 
 .n-syndication-icon-state-maintenance {
 	background-image: none;
-	}
+}
 
 .o-teaser--top-story .n-syndication-icon,
 .topper__headline .n-syndication-icon {
@@ -66,7 +90,7 @@
 	height: 26px;
 	vertical-align: baseline;
 	width: 26px;
-	}
+}
 
 .hero__heading .n-syndication-icon,
 .o-teaser--hero .n-syndication-icon,
@@ -78,37 +102,61 @@
 	height: 24px;
 	vertical-align: baseline;
 	width: 24px;
-	}
+}
 
 .o-teaser__related .o-teaser__related-item .n-syndication-icon {
-		border-radius: 16px;
-		height: 16px;
-		width: 16px;
+	border-radius: 16px;
+	height: 16px;
+	width: 16px;
 }
 
 .hero__heading .n-syndication-icon {
 	vertical-align: baseline;
-	}
+}
 
 // modal
-
 .n-syndication-modal-shadow {
-	@include oOverlayShadow();
-	}
+	background-color: rgba(0, 0, 0, 0.2);
+	position: fixed;
+	height: 150%; // because on some phones scrolling upwards detaches a 100% height overlay from the bottom of the screen
+	width: 100%;
+	top: 0;
+	left: 0;
+	z-index: 10;
+	opacity: 1;
+	transition: opacity 0.3s ease-in-out;
+}
 .n-syndication-modal {
-	@include oOverlay();
+	@include oVisualEffectsShadowContent($elevation: "high");
+	position: fixed;
+	z-index: 10;
+	box-sizing: border-box;
+	opacity: 1;
+	transition: opacity 0.3s ease-in-out;
+	border: $_o-overlay-border-width solid _oOverlayGet("default-border");
+	background: _oOverlayGet("default-background");
 
 	min-height: 160px;
 	max-width: 420px;
 	min-width: 360px;
 	//position: absolute;
 	z-index: 1000;
-	}
+}
 .n-syndication-modal-heading {
-	@include oOverlayHeading();
-	}
+	font-size: 20px;
+	margin: 0;
+	overflow: hidden;
+	background: _oOverlayGet("heading-background");
+	color: _oOverlayGet("heading-text");
+}
 .n-syndication-modal-close {
-	@include _oOverlayCloseIcon(oColorsGetColorFor(o-overlay-close, border));
+	@include oIconsContent(
+		$icon-name: "cross",
+		$color: oColorsByName("white"),
+		$size: 20
+	);
+	background-size: contain;
+
 	border-width: 0;
 	box-sizing: content-box;
 	float: right;
@@ -131,84 +179,108 @@
 	// Increase hit zone of the button around it for better usability
 	&:after {
 		position: absolute;
-		content: '';
+		content: "";
 		top: -10px;
 		right: -10px;
 		left: -10px;
 		bottom: -10px;
 	}
-	}
+}
 .n-syndication-modal-title {
-	@include oOverlayTitle();
+	margin: 10px 10px 10px 20px;
+	display: block;
+	line-height: 25px;
+	overflow: auto;
+
 	font-family: "financier display", "times new roman", serif;
 	font-size: 24px;
 	font-weight: normal;
 	line-height: 26px;
-	}
+}
 .n-syndication-modal-word-count {
-	color: rgba(getColor('black'), 0.4);
+	color: rgba(oColorsByName("black"), 0.4);
 	font-family: metric, arial, sans-serif;
 	font-size: 16px;
 	font-weight: normal;
-	}
+}
 .n-syndication-modal-content {
-	@include oOverlayContent();
-	padding-top: 0;
+	position: relative;
+	box-sizing: border-box;
+	overflow: auto;
+	padding: 20px;
+
+	> *:first-child {
+		margin-top: 0;
 	}
+
+	> *:last-child {
+		margin-bottom: 0;
+	}
+
+	padding-top: 0;
+}
 
 .n-syndication-modal-message,
 .n-syndication-modal-message p {
-	color: rgba(getColor('black'), 0.8);
+	color: rgba(oColorsByName("black"), 0.8);
 	font-family: metric, arial, sans-serif;
 	font-size: 14px;
 	line-height: 20px;
-	}
+}
 
 .n-syndication-actions {
 	text-align: right;
-	}
+}
 .n-syndication-action {
-	@include oButtons(default, secondary);
+	@include oButtons(
+		$opts: (
+			"type": "secondary"
+		)
+	);
 }
 .n-syndication-action-primary {
-	@include oButtons(default, primary);
+	@include oButtons(
+		$opts: (
+			"type": "primary"
+		)
+	);
 }
 .n-syndication-action,
 .n-syndication-action-primary {
 	min-width: 120px;
 	text-align: center;
-	}
+}
 
 .n-syndication-republishing {
-	background-color: rgba(getColor('claret'), 1);
-	color: getColor('white');
+	background-color: rgba(oColorsByName("claret"), 1);
+	color: oColorsByName("white");
 	font-weight: bold;
-	}
+}
 
 .o-header__nav-item .n-syndication-republishing {
 	padding-left: 12px;
 	padding-right: 12px;
 
 	&:hover {
-		color: getColor('white');
+		color: oColorsByName("white");
 
 		&:after {
-			background-color: getColor('white');
-			}
+			background-color: oColorsByName("white");
 		}
 	}
+}
 
 .o-header__drawer-menu-item .n-syndication-republishing {
-	background-color: rgba(getColor('claret'), 0.75);
+	background-color: rgba(oColorsByName("claret"), 0.75);
 	transition: all 250ms ease-in-out;
 
 	&:hover {
-		background-color: rgba(getColor('claret'), 1);
-		color: getColor('white');
-		}
+		background-color: rgba(oColorsByName("claret"), 1);
+		color: oColorsByName("white");
 	}
+}
 
 .n-syndication-modal-message .syndication-message__content--warning {
-	color: getColor('crimson');
+	color: oColorsByName("crimson");
 	font-weight: 600;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -3,8 +3,6 @@
 @import "o-overlay/main";
 @import "o-visual-effects/main";
 
-$system-code: "n-syndication";
-
 .n-syndication-icon {
 	@include oIconsContent(
 		$icon-name: "cross",

--- a/test/main.scss
+++ b/test/main.scss
@@ -1,0 +1,3 @@
+$system-code: "n-syndication";
+
+@import "../src/scss/main";


### PR DESCRIPTION
Deprecated o-overlay mixins have been added verbatim: the latest
version of oOverlay isn't compatible with implementations that attempted
to recreate behaviour component-by-component.

WIP while `n-ui-foundations` is being upgraded

🐿 v2.12.5