### PR TITLE
Fix video download bug in syndication

### DIFF
--- a/src/js/modal-download.js
+++ b/src/js/modal-download.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import {broadcast} from 'n-ui-foundations';
-import {listenTo} from 'o-viewport';
+import oViewport from 'o-viewport';
 import Superstore from 'superstore';
 
 import {getMessage, TRACKING} from './config';
@@ -26,7 +26,7 @@ function init (user) {
 	addEventListener('keyup', actionModalFromKeyboard, true);
 	addEventListener('resize', reposition, true);
 
-	listenTo('resize');
+	oViewport.listenTo('resize');
 
 	USER_DATA = user;
 }


### PR DESCRIPTION
When `next-video-page` was migrated from `n-ui` to `dotcom-page-kit`, it inadvertently broke video download in syndication.

Once it was migrated, `o-viewport` was no longer being imported correctly and it caused the `n-syndication` to error before `USER_DATA` (necessary for video downloads) was set.

What changed from `n-ui` to `dotcom-page-kit`? With `n-ui` all code is transpiled to use the CommonJS module format and a plugin is used to check for a default export. If it comes across
one, as it does with `o-viewport`, it injects this:

```
exports.default = {listenTo, ...};

module.exports = exports.default;
```

This allowed `o-viewport` to be imported like this:

```
import {listenTo} from 'o-viewport';
listenTo();
```

`dotcom-page-kit` doesn't do this which is why `listenTo` from `o-viewport` can only be accessed like this:

```
import oViewport from 'o-viewport';
oViewport.listenTo();
```

Ops Cop ticket: https://financialtimes.atlassian.net/jira/software/projects/NOPSCOPS/boards/952?selectedIssue=NOPSCOPS-81