### PR TITLE
Exclude subnav elements from the syndication request call 🐿 v2.12.5

### DIFF
--- a/src/js/data-store.js
+++ b/src/js/data-store.js
@@ -45,30 +45,34 @@ async function fetchItems (itemIDs) {
 		body: JSON.stringify(itemIDs)
 	};
 
-	try {
-		const response = await fetch(`/syndication/resolve${location.search}`, options);
+	if(options.body.length) {
 
-		if (!response.ok) {
-			const text = await response.text();
-			throw new Error(`Next /syndication/resolve responded with "${text}" (${response.status})`);
+		try {
+			const response = await fetch(`/syndication/resolve${location.search}`, options);
+
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(`Next /syndication/resolve responded with "${text}" (${response.status})`);
+			}
+
+			const items = await response.json();
+
+			broadcast('nSyndication.fetch', {
+				request: itemIDs,
+				response: items
+			});
+
+			return items;
+
+		} catch (error) {
+			broadcast('oErrors.log', {
+				error,
+				info: {
+					component: 'next-syndication-redux'
+				}
+			});
 		}
 
-		const items = await response.json();
-
-		broadcast('nSyndication.fetch', {
-			request: itemIDs,
-			response: items
-		});
-
-		return items;
-
-	} catch (error) {
-		broadcast('oErrors.log', {
-			error,
-			info: {
-				component: 'next-syndication-redux'
-			}
-		});
 	}
 }
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -31,7 +31,7 @@ function getContentIDFromHTMLElement (el) {
 
 		// there is a case where an item has a `data-content-id` with no value.
 		// I can't figure it out right now, so temporary "fix"...
-		if (!id) {
+		if (!id && !el.classList.contains('o-header__subnav-item')) {
 			id = el.getAttribute('data-id');
 
 			if (!id) {


### PR DESCRIPTION
This excludes subnav elements from the array of elements sent to the syndication service and prevents the `/syndication/resolve` controller from being called if there are no syndicatable items on the page

In n-ui builds, the myFT subnav elements contain a `data-id` property. These are being mistakenly picked up by the current logic in n-syndication which uses `data-id` to create a list of syndicatable elements. 

![Screenshot 2020-01-13 at 15 21 24](https://user-images.githubusercontent.com/17549437/72268121-2c16de80-3619-11ea-90d1-10350a207c18.png)

This PR excludes subnav elements from the list above. 

It also prevents the syndication service from being called on a page if this list is empty because the [next-syndication-api](https://github.com/Financial-Times/next-syndication-api/blob/master/server/controllers/resolve.js#L26-L33) will throw an error if it receives an empty list. 
