### PR TITLE
fixes empty items check before the resolve syndication call 🐿 v2.12.5

### DIFF
--- a/src/js/data-store.js
+++ b/src/js/data-store.js
@@ -45,7 +45,7 @@ async function fetchItems (itemIDs) {
 		body: JSON.stringify(itemIDs)
 	};
 
-	if(options.body.length) {
+	if(itemIDs.length) {
 
 		try {
 			const response = await fetch(`/syndication/resolve${location.search}`, options);


### PR DESCRIPTION
Fixes the implementation in https://github.com/Financial-Times/n-syndication/pull/64 which tries to prevent a call to the syndication service from being made if there are no syndicatable elements on the page. 

Checking `itemsIDs.length` rather than `options.body.length` will correctly return 0 if there are no syndicatable items are found on the page.

[Illuminating explanation](https://github.com/Financial-Times/n-syndication/pull/64/files#r365920142) from @i-like-robots  