### PR TITLE
Upgrade Node version -> v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node12: &container_config_node12
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node12: &container_config_lambda_node12
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs12.x
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - checkout
       - run:
@@ -90,7 +90,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {},
   "config": {},
   "engines": {
-    "node": "^8.11.1"
+    "node": "12.x"
   },
   "scripts": {
     "commit": "commit-wizard",


### PR DESCRIPTION
I am upgrading the Node version of `next-session-client` to Node v12 (the current LTS version) in this [PR](https://github.com/Financial-Times/next-session-client/pull/52).

`next-session-client` is consumed by this app, and so it would make sense for everything to be aligned on the same Node version, and so this PR updates this app's Node version to v12.