### PR TITLE
Add @babel/runtime dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "main.js",
   "description": "Implementation for the syndication indicator, for users who subscribe to the new FT syndication platform",
   "devDependencies": {
+    "@babel/runtime": "^7.10.2",
     "@financial-times/n-gage": "^5.1.2",
     "@financial-times/n-heroku-tools": "^8.0.0",
     "autoprefixer": "^6.3.6",


### PR DESCRIPTION
When `bower link`ing from this component to `next-front-page` and then running `make build` (on `next-front-page`) I encountered this error:

<img width="945" alt="Screenshot 2020-06-18 at 16 05 39" src="https://user-images.githubusercontent.com/10484515/85037837-c4dbf800-b17d-11ea-911d-cf5c70a32636.png">

Which presents itself again in the client-side console:

<img width="445" alt="Screenshot 2020-06-18 at 16 05 53" src="https://user-images.githubusercontent.com/10484515/85037882-d7eec800-b17d-11ea-87d8-dd6d53545d50.png">

An investigation suggested that I install `babel-runtime` as a dev dependency, which has resolved the issue and enabled me to run `next-front-page` locally whilst `bower link`ing to a local instance of `n-syndication`.

#### References:
- [GitHub wojtekmaj/react-pdf - Issues: "Module not found: Error: Can't resolve 'babel-runtime/regenerator'"](https://github.com/wojtekmaj/react-pdf/issues/310#issuecomment-463425172).

#### New dev dependencies:
- [npm: @babel/runtime](https://www.npmjs.com/package/@babel/runtime).
- [Babel: @babel/runtime](https://babeljs.io/docs/en/next/babel-runtime.html).