### PR TITLE
CI-223 Update topper headline class names

### DIFF
--- a/src/js/iconify.js
+++ b/src/js/iconify.js
@@ -16,9 +16,9 @@ const SYNDICATION_INSERTION_RULES = {
 	// matcher for x-teaser
 	'.o-teaser': {fn: 'querySelector', slc: '.o-teaser__heading'},
 	'.stream-item': {fn: 'querySelector', slc: '.card-openable__headline'},
-	'article[class="article"]': {fn: 'querySelector', slc: '.topper__headline'},
-	'article.article--brand': {fn: 'querySelector', slc: '.topper__headline'},
-	'article.article-grid': {fn: 'querySelector', slc: '.topper__headline', up: 1},
+	'article[class="article"]': {fn: 'querySelector', slc: '.o-topper__headline'},
+	'article.article--brand': {fn: 'querySelector', slc: '.o-topper__headline'},
+	'article.article-grid': {fn: 'querySelector', slc: '.o-topper__headline', up: 1},
 	'div.hero': {fn: 'querySelector', slc: '.hero__heading'},
 	'main.video': {fn: 'querySelector', slc: '.video__title'},
 	'li.o-teaser__related-item': {}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -83,7 +83,7 @@
 }
 
 .o-teaser--top-story .n-syndication-icon,
-.topper__headline .n-syndication-icon {
+.o-topper__headline .n-syndication-icon {
 	border-radius: 26px;
 	height: 26px;
 	vertical-align: baseline;


### PR DESCRIPTION
Content Innovation is in the process of updating all `next-article` toppers to use `o-topper`. This involves updating all class names so `o-topper` can apply the correct styles.

`n-syndication` relies on `topper__headline` to exist on the page which won't be the case when we move to `o-topper`. This PR updates the class name to `o-topper__headline`. I've confirmed it all works by running the component locally with `next-article`.

See https://github.com/Financial-Times/next-article/pull/3934

Incident page: https://response.ftops.tech/incident/697