### PR TITLE
ACC-544 rich_articles not rich article

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -12,6 +12,8 @@ export async function init (flags) {
 		return;
 	}
 
+	debugger;
+
 	const syndicationAccess = await getSyndicationAccess();
 
 	if (!syndicationAccess.length || !syndicationAccess.includes(SYNDICATION_ACCESS.STANDARD)) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -12,8 +12,6 @@ export async function init (flags) {
 		return;
 	}
 
-	debugger;
-
 	const syndicationAccess = await getSyndicationAccess();
 
 	if (!syndicationAccess.length || !syndicationAccess.includes(SYNDICATION_ACCESS.STANDARD)) {

--- a/src/js/messages.js
+++ b/src/js/messages.js
@@ -45,6 +45,14 @@ export function getMessage (item, {MAINTENANCE_MODE, contributor_content}) {
 	return interpolate(message, item);
 }
 
+export function getAdditionalMessages (item, user) {
+	const richContentMessages = richContentMessage(item, user);
+
+	return richContentMessages
+		.map(messageTemplate)
+		.join('');
+}
+
 export function richContentMessage (
 	{ hasGraphics = false, canAllGraphicsBeSyndicated = false } = {},
 	{ download_format = 'plain', allowed = {} } = {}
@@ -58,17 +66,29 @@ export function richContentMessage (
 				messageType: 'neutral',
 				message: MESSAGES.GRAPHICS,
 			});
-
-			//Nested condition because only required if first condition true
-			if (download_format && download_format !== 'docx') {
-
-				messagesContent.push({
-					messageType: 'error',
-					message: MESSAGES.WORD_FORMAT,
-				});
-			}
 		}
+
+		if (hasGraphics && download_format !== 'docx') {
+			messagesContent.push({
+				messageType: 'error',
+				message: MESSAGES.WORD_FORMAT,
+			});
+		}
+
 	}
 
 	return messagesContent;
+}
+
+function messageTemplate ({ messageType = 'neutral', messageText = '' }) {
+
+	return `<div class="o-message o-message--alert o-message--${messageType} n-syndication-rich-content-message" data-o-component="o-message">
+		<div class="o-message__container">
+			<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight n-syndication-rich-message_content-highlight">${messageText}</span>
+				</p>
+			</div>
+		</div>
+	</div>`;
 }

--- a/src/js/messages.js
+++ b/src/js/messages.js
@@ -52,7 +52,7 @@ export function richContentMessage (
 
 	const messagesContent = [];
 
-	if (allowed.rich_article) {
+	if (allowed.rich_articles) {
 		if (hasGraphics && !canAllGraphicsBeSyndicated) {
 			messagesContent.push({
 				messageType: 'neutral',

--- a/src/js/messages.js
+++ b/src/js/messages.js
@@ -80,13 +80,13 @@ export function richContentMessage (
 	return messagesContent;
 }
 
-function messageTemplate ({ messageType = 'neutral', messageText = '' }) {
+function messageTemplate ({ messageType = 'neutral', message = '' }) {
 
 	return `<div class="o-message o-message--alert o-message--${messageType} n-syndication-rich-content-message" data-o-component="o-message">
 		<div class="o-message__container">
 			<div class="o-message__content">
 				<p class="o-message__content-main">
-					<span class="o-message__content-highlight n-syndication-rich-message_content-highlight">${messageText}</span>
+					<span class="o-message__content-highlight n-syndication-rich-message_content-highlight">${message}</span>
 				</p>
 			</div>
 		</div>

--- a/src/js/modal-download.js
+++ b/src/js/modal-download.js
@@ -8,7 +8,7 @@ import {TRACKING} from './config';
 
 import {toElement} from './util';
 import {getAllItemsForID, getItemByHTMLElement} from './data-store';
-import {getMessage, richContentMessage } from './messages';
+import {getMessage, getAdditionalMessages } from './messages';
 
 const MAX_LOCAL_FORMAT_TIME_MS = 300000;
 const localStore = new Superstore('local', 'syndication');
@@ -160,6 +160,8 @@ function createElement (item) {
 		downloadTrackingId = 'download-items';
 	}
 
+	debugger;
+
 	return toElement(`<div class="n-syndication-modal-shadow"></div>
 							<div class="n-syndication-modal n-syndication-modal-${item.type}" role="dialog" aria-labelledby="'Download:  ${title}" tabindex="0">
 								<header class="n-syndication-modal-heading">
@@ -171,7 +173,7 @@ function createElement (item) {
 									<div class="n-syndication-modal-message">
 									${getMessage(item, USER_DATA)}
 									</div>
-									${richContentWarnings (item)}
+									${getAdditionalMessages (item, USER_DATA)}
 									<div class="n-syndication-actions" data-content-id="${item.id}" data-iso-lang="${item.lang}">
 										<a class="n-syndication-action" data-action="save" ${disableSaveButton ? 'disabled' : ''} data-trackable="${saveTrackingId}" href="${saveHref}">${saveText}</a>
 										<a class="n-syndication-action n-syndication-action-primary" data-action="download" ${disableDownloadButton ? 'disabled' : ''} ${downloadTrackingId ? `data-trackable="${downloadTrackingId}"` : ''} href="${downloadHref}">${downloadText}</a>
@@ -299,33 +301,6 @@ function show (evt) {
 
 function visible () {
 	return !!(OVERLAY_MODAL_ELEMENT && document.body.contains(OVERLAY_MODAL_ELEMENT));
-}
-
-function messageTemplate (messageType = 'neutral', messageText) {
-
-	return `<div class="o-message o-message--alert o-message--${messageType} n-syndication-rich-content-message" data-o-component="o-message">
-		<div class="o-message__container">
-			<div class="o-message__content">
-				<p class="o-message__content-main">
-					<span class="o-message__content-highlight n-syndication-rich-message_content-highlight">${messageText}</span>
-				</p>
-			</div>
-		</div>
-	</div>`;
-}
-
-function richContentWarnings (item) {
-	const theMessages = richContentMessage(item, USER_DATA);
-
-	if (theMessages.length === -1) {
-		return null;
-	}
-
-	const richContentWarningsMessages = theMessages
-		.map((message) => messageTemplate(message.messageType, message.message))
-		.join('');
-
-	return richContentWarningsMessages;
 }
 
 

--- a/src/js/modal-download.js
+++ b/src/js/modal-download.js
@@ -160,8 +160,6 @@ function createElement (item) {
 		downloadTrackingId = 'download-items';
 	}
 
-	debugger;
-
 	return toElement(`<div class="n-syndication-modal-shadow"></div>
 							<div class="n-syndication-modal n-syndication-modal-${item.type}" role="dialog" aria-labelledby="'Download:  ${title}" tabindex="0">
 								<header class="n-syndication-modal-heading">

--- a/test/src/js/messages.spec.js
+++ b/test/src/js/messages.spec.js
@@ -36,7 +36,7 @@ describe('messages', () => {
 		const msg2 = { messageType: 'error', message: MESSAGES.WORD_FORMAT };
 
 		beforeEach(() => {
-			userStatusFixture.allowed.rich_article = true;
+			userStatusFixture.allowed.rich_articles = true;
 		});
 
 		it('returns an empty string if item does not have graphics', () => {

--- a/test/src/js/messages.spec.js
+++ b/test/src/js/messages.spec.js
@@ -91,5 +91,17 @@ describe('messages', () => {
 			expect(richContentMsg[0]).toEqual(msg1);
 			expect(richContentMsg[1]).toEqual(msg2);
 		});
+
+		it('returns a string of HTML that contains the graphics unavailable message AND the word format message if hasGraphics is TRUE and canAllGraphicsBeSyndicated is TRUE and download_format is NOT docx', () => {
+			const items = Object.assign({}, itemsFixture, { hasGraphics: true, canAllGraphicsBeSyndicated: true });
+			const userStatus = Object.assign({}, userStatusFixture, {
+				download_format: 'plain',
+			});
+			const richContentMsg = richContentMessage(items, userStatus);
+
+			expect(Array.isArray(richContentMsg)).toBe(true);
+			expect(richContentMsg.length).toBe(1);
+			expect(richContentMsg[0]).toEqual(msg2);
+		});
 	});
 });


### PR DESCRIPTION
Fixes check condition typo of  `allowed.rich_article` to  `allowed.rich_articles` as per the property returned by next-syndication-api

Updates logic for when “WORD” isn’t a default download format, 
Shows message when user has rich article licence, the content(article) has graphics, and users download format isn’t word