### PR TITLE
NOPS-619 potential solution for misaligned syndication icons

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -87,7 +87,7 @@
 .o-topper__headline .n-syndication-icon {
 	border-radius: 26px;
 	height: 26px;
-	vertical-align: baseline;
+	vertical-align: middle;
 	width: 26px;
 }
 
@@ -99,7 +99,7 @@
 .video__description .video__title .n-syndication-icon {
 	border-radius: 24px;
 	height: 24px;
-	vertical-align: baseline;
+	vertical-align: middle;
 	width: 24px;
 }
 
@@ -110,7 +110,7 @@
 }
 
 .hero__heading .n-syndication-icon {
-	vertical-align: baseline;
+	vertical-align: middle;
 }
 
 // modal


### PR DESCRIPTION
Ticket: https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1137&projectKey=NOPS&modal=detail&selectedIssue=NOPS-619

Needs local testing.

Changes the value of the property `vertical-align` from `baseline` to `middle`.