### PR TITLE
NOPS-619: Fix syndication icons alignment

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -18,8 +18,12 @@
 	display: inline-block;
 	height: 20px;
 	margin-right: 2px;
-	vertical-align: text-top;
+	vertical-align: middle;
 	width: 20px;
+}
+
+.n-syndication-icon + * {
+	vertical-align: middle;
 }
 
 .n-syndication-icon.n-syndication-icon-state-no,

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -37,7 +37,8 @@
 	@include oIconsContent(
 		$icon-name: "cross",
 		$color: oColorsByName("white"),
-		$size: 20
+		$size: 20,
+		$include-base-styles: false
 	);
 	background-color: rgba(oColorsByName("claret"), 0.85);
 }
@@ -50,7 +51,8 @@
 	@include oIconsContent(
 		$icon-name: "tick",
 		$color: oColorsByName("white"),
-		$size: 20
+		$size: 20,
+		$include-base-styles: false
 	);
 	background-color: rgba(oColorsByName("jade"), 0.85);
 }
@@ -62,7 +64,8 @@
 	@include oIconsContent(
 		$icon-name: "dollar",
 		$color: oColorsByName("white"),
-		$size: 20
+		$size: 20,
+		$include-base-styles: false
 	);
 	background-color: rgba(oColorsByName("jade"), 0.85);
 }
@@ -74,7 +77,8 @@
 	@include oIconsContent(
 		$icon-name: "minus",
 		$color: oColorsByName("white"),
-		$size: 20
+		$size: 20,
+		$include-base-styles: false
 	);
 	background-color: rgba(oColorsByName("mandarin"), 0.85);
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -26,13 +26,6 @@
 	vertical-align: middle;
 }
 
-.n-syndication-icon.n-syndication-icon-state-no,
-.n-syndication-icon.n-syndication-icon-state-verify,
-.n-syndication-icon.n-syndication-icon-state-withcontributorpayment,
-.n-syndication-icon.n-syndication-icon-state-yes {
-	vertical-align: text-top;
-}
-
 .n-syndication-icon-state-msg_4000,
 .n-syndication-icon-state-msg_4050,
 .n-syndication-icon-state-msg_5000,
@@ -95,7 +88,6 @@
 .o-topper__headline .n-syndication-icon {
 	border-radius: 26px;
 	height: 26px;
-	vertical-align: baseline;
 	width: 26px;
 }
 
@@ -107,7 +99,6 @@
 .video__description .video__title .n-syndication-icon {
 	border-radius: 24px;
 	height: 24px;
-	vertical-align: baseline;
 	width: 24px;
 }
 
@@ -115,10 +106,6 @@
 	border-radius: 16px;
 	height: 16px;
 	width: 16px;
-}
-
-.hero__heading .n-syndication-icon {
-	vertical-align: baseline;
 }
 
 // modal


### PR DESCRIPTION
A fix to ensure that the syndication icons have a consistent alignment with its' sibling inline elements. 

Currently we have a few overrides to try an ensure there is a fixed value for the `vertical-align` rule however seems to be a symptom of `oIconsContent(...)` resetting the base icon style rules. This fix uses the `$include-base-styles: false` option that removes these base icon style rules removing the need to override the `vertical-align` rule for different variations. This fix also adds the `vertical-align: middle` rule to any sibling of `.n-syndication-icon` to make sure the alignment between these inline elements is consistent.

Closes #82 as this will remove the duplicated vertical-align overrides to create one consistent (🤞 ) style.

Here is some screen recordings of the new syndication icon layout (in maintenance mode) for Chrome, Safari, Firefox, and iOS Safari:

https://user-images.githubusercontent.com/893208/126464259-6a0c92bf-bb09-4137-b745-001c070a2143.mov

https://user-images.githubusercontent.com/893208/126464398-92efee1b-1440-4e6a-b5ad-a66c4d482c80.mov

https://user-images.githubusercontent.com/893208/126464591-e553261a-f073-409a-bb7c-efc8ef5da8f0.mov

https://user-images.githubusercontent.com/893208/126464651-091e231a-6a0b-4b37-a1d5-a8c4205265e3.mov



