### PR TITLE
Add new rule for icon insertion

### DIFF
--- a/src/js/iconify.js
+++ b/src/js/iconify.js
@@ -21,7 +21,8 @@ const SYNDICATION_INSERTION_RULES = {
 	'article.article-grid': {fn: 'querySelector', slc: '.o-topper__headline', up: 1},
 	'div.hero': {fn: 'querySelector', slc: '.hero__heading'},
 	'main.video': {fn: 'querySelector', slc: '.video__title'},
-	'li.o-teaser__related-item': {}
+	'li.o-teaser__related-item': {},
+	'.js-teaser-headline': {}
 };
 let USER_DATA;
 


### PR DESCRIPTION
This rule is used for beta homepage(next-discovery-pages)

This `js-teaser-headline` class is added to beta homepage by [this PR](https://github.com/Financial-Times/next-discovery-pages/pull/590)

[Jira ticket](https://financialtimes.atlassian.net/browse/CON-903)