### PR TITLE
ACC-1169 main branch name change chores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -123,7 +123,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 _extends: github-apps-config-next
 
 branches:
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews: null
       required_status_checks:

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ The Content API has the property `canBeSyndicated` which is a string containing 
 ## This is just some javascript - is there other code elsewhere?
 Yep - These links will probably be wrong pretty soon but will hopefully point you in the right direction:
 
-**n-teaser** - https://github.com/Financial-Times/n-teaser/blob/master/src/presenters/teaser-presenter.js#L77
+**n-teaser** - https://github.com/Financial-Times/n-teaser/blob/main/src/presenters/teaser-presenter.js#L77
 Here we add an additional modifier if syndication is available on this article
 
-**next-article** - https://github.com/Financial-Times/next-article/blob/master/views/content.html#L20
+**next-article** - https://github.com/Financial-Times/next-article/blob/main/views/content.html#L20
 Here a data attribute is added containing the syndication status of the article.
 
 **generic** - add the following data attributes to your markup:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Implementation for the syndication indicator, for users who subscribe to the new FT syndication platform",
   "devDependencies": {
     "@babel/runtime": "^7.10.2",
-    "@financial-times/n-gage": "^5.1.2",
+    "@financial-times/n-gage": "^8.3.2",
     "@financial-times/n-heroku-tools": "^8.0.0",
     "@sucrase/jest-plugin": "^2.0.0",
     "autoprefixer": "^6.3.6",


### PR DESCRIPTION
**Description**
Following the branch name change, this PR handles associated chores as per https://github.com/Financial-Times/next/wiki/Migrating-apps-to-use-main-branch-(instead-of-master)
- upgrades n-gage
- updates CI yaml to use the new name
- updates new name in links

**Ticket**
https://financialtimes.atlassian.net/browse/ACC-1169

**We're bumping how many n-gage versions?!**
TOO MANY. But I think none of those changes affect this repo.
v8.0.0 - the package-lock.json change is opt in https://github.com/Financial-Times/n-gage/releases/tag/v8.0.0
v7.0.0 - is an upgrade to Node v12 https://github.com/Financial-Times/n-gage/releases/tag/v7.0.0
v6.0.0 - something to do with asset-hashes.json, action only needed if this file is present in the project