### PR TITLE
Allow apps to pin point syndication elements

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -35,7 +35,7 @@ export async function init (flags) {
 	}
 
 	initDataStore(user);
-	initIconify(user);
+	initIconify(user, flags);
 	initDownloadModal(user);
 	$$('.video__actions__download').forEach(el => el.parentNode.removeChild(el));
 }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -27,7 +27,7 @@ function getContentIDFromHTMLElement (el) {
 		}
 
 		//		if (el.hasAttribute(ATTR_CONTENT_ID)) {
-		let id = el.getAttribute('data-content-id');
+		let id = el.getAttribute('data-syndication-content-id') || el.getAttribute('data-content-id');
 
 		// there is a case where an item has a `data-content-id` with no value.
 		// I can't figure it out right now, so temporary "fix"...


### PR DESCRIPTION
### Current problem

n-syndication has lots of hardcoded selectors that it uses to find elements to attach icons to

These selectors are very opinionated about the html of the apps. This can cause issues when needing to change the html in those apps.

### Proposed solution

Introduce a new selector data-syndication-content-id which the apps can apply to any element that should have a syndication icon.

This allows apps to change their html and as long as they move/keep this attribute on the correct elements then syndication should work

I am proposing we trial this on next-article and I have used a flag so we can switch it off quickly if it causes any issues.

If this works well and we managed to get all other apps to adapter the same process I believe we could delete large and complex parts of n-syndication

### How this changes consuming apps

Here is an over simplified break down of how this changes a standard article in next-article for the main headline.

It starts by getting all elements with a `data-content-id` attribute and then see if that element matches any of the rules in [this object](https://github.com/Financial-Times/n-syndication/blob/main/src/js/iconify.js#L9-L26)

In this case it matches the [`article.article-grid` selector](https://github.com/Financial-Times/n-syndication/blob/main/src/js/iconify.js#L21)

```diff
<div>
    <div class="o-topper">
        <h1 class="o-topper__headline">Article headline</h1>
    </div>
+    <article class="article-grid" data-content-id="12345">
        Article content
    </article>
</div>
```

It then uses the value of the key that it matches which contains a `fn` property, a `slc ` property and sometimes a `up` property. I think `slc` stands for selector but 🤷 

In our example `fn` is `querySelector`, `slc` is `.o-topper__headline` and `up` is 1.

The `up` value in our case means we are going up one level to the elements parent

```diff
+ <div>
    <div class="o-topper">
        <h1 class="o-topper__headline">Article headline</h1>
    </div>
     <article class="article-grid" data-content-id="12345">
        Article content
    </article>
</div>
```

On this parent we are then using the `fn` value to search for the `slc` property. So on the parent we are running a queryselector looking for `.o-topper__headline`

```diff
 <div>
    <div class="o-topper">
+        <h1 class="o-topper__headline">Article headline</h1>
    </div>
     <article class="article-grid" data-content-id="12345">
        Article content
    </article>
</div>
```

Once this all matches then the icon is applied to that element.

With my proposal the difference would be that the `o-topper__headline` element has a `data-syndication-content-id` attribute applied to it by next-article and then n-syndication uses this to know that this is the element we want an icon to be applied to. Which means all of the above hoop jumping through very specific markup is no longer needed.

```diff
 <div>
    <div class="o-topper">
+        <h1 class="o-topper__headline" data-syndication-content-id="12345">Article headline</h1>
    </div>
     <article class="article-grid" data-content-id="12345">
        Article content
    </article>
</div>
```

### Extra notes

I tried to write tests for this thinking it should be easy enough.. how I was wrong. Theres lots of dependencies on other files and dom events so I figuring this was outside of my remit for a proposal as it is already not tested and I wanted to time box this.

I have manually been testing this by linking these changes to next-article and making sure it works how I expect. However I am not massively familiar with syndication so there might be some differences that I am not aware of