### PR TITLE
ACC-1360 update bower components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,11 +20,11 @@
   "dependencies": {
     "n-ui-foundations": "^6.0.0",
     "next-session-client": "^3.0.1",
-    "o-buttons": "^6.0.2",
+    "o-buttons": "^6.0.0",
     "o-overlay": "^3.0.0",
-    "o-tracking": "^2.0.3",
+    "o-tracking": "^3.0.0",
     "o-visual-effects": "^3.0.0",
-    "o-message": "^4.1.8",
-    "o-icons": "^6.3.0"
+    "o-message": "^4.0.0",
+    "o-icons": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   "dependencies": {
     "n-ui-foundations": "github:financial-times/n-ui-foundations#nobower",
     "next-session-client": "^3.0.1",
-    "o-buttons": "npm:@financial-times/o-buttons@^6.0.2",
-    "o-icons": "npm:@financial-times/o-icons@^6.3.0",
-    "o-message": "npm:@financial-times/o-message@^4.1.8",
+    "o-buttons": "npm:@financial-times/o-buttons@^6.0.0",
+    "o-icons": "npm:@financial-times/o-icons@^6.0.0",
+    "o-message": "npm:@financial-times/o-message@^4.0.0",
     "o-overlay": "npm:@financial-times/o-overlay@^3.0.0",
-    "o-tracking": "npm:@financial-times/o-tracking@^2.0.3",
+    "o-tracking": "npm:@financial-times/o-tracking@^3.0.0",
     "o-viewport": "npm:@financial-times/o-viewport@^5.0.0",
     "o-visual-effects": "npm:@financial-times/o-visual-effects@^3.0.0",
     "superstore": "^2.1.0"


### PR DESCRIPTION
Updating origami components to their latest bower available version: https://origami.ft.com/blog/2021/07/01/origami-on-npm-and-how-to-migrate/#last-bower-releases


[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1360)