### PR TITLE
sort out linting issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: ['@financial-times/eslint-config-next']
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .DS_Store
 .editorconfig
-.eslintrc.js
 .stylelintrc
 .vscode
 *.env*
 
 /node_modules/
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@babel/runtime": "^7.10.2",
+        "@financial-times/eslint-config-next": "^7.0.0",
         "@financial-times/n-gage": "^9.0.1",
         "@financial-times/n-heroku-tools": "^14.0.0",
         "@financial-times/o-buttons": "^7.3.0",
@@ -950,13 +951,18 @@
       }
     },
     "node_modules/@financial-times/eslint-config-next": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
-      "integrity": "sha512-cOwrhMrXlCd/TiD42EQdx0s8VXiELYpSJn+mI6TZrZ0YdaRw9ykcszRRQe/HA5zN8Srr/8izJzVT1yJ0RkN1vg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-7.0.0.tgz",
+      "integrity": "sha512-Pzth07nOI3TZ3SALcLiXJR/6W6bL3eyLBA4xPF3ZkZnyVh1UDd5oLT/G++cI2bami1qNSvhCn+E+AUV5XGdRow==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "eslint": ">=5.0.0",
         "eslint-plugin-no-only-tests": ">=2.0.0"
+      },
+      "engines": {
+        "node": "16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/fticons": {
@@ -1016,6 +1022,16 @@
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@financial-times/n-gage/node_modules/@financial-times/eslint-config-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
+      "integrity": "sha512-cOwrhMrXlCd/TiD42EQdx0s8VXiELYpSJn+mI6TZrZ0YdaRw9ykcszRRQe/HA5zN8Srr/8izJzVT1yJ0RkN1vg==",
+      "dev": true,
+      "dependencies": {
+        "eslint": ">=5.0.0",
+        "eslint-plugin-no-only-tests": ">=2.0.0"
       }
     },
     "node_modules/@financial-times/n-gage/node_modules/acorn": {
@@ -20565,9 +20581,9 @@
       }
     },
     "@financial-times/eslint-config-next": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
-      "integrity": "sha512-cOwrhMrXlCd/TiD42EQdx0s8VXiELYpSJn+mI6TZrZ0YdaRw9ykcszRRQe/HA5zN8Srr/8izJzVT1yJ0RkN1vg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-7.0.0.tgz",
+      "integrity": "sha512-Pzth07nOI3TZ3SALcLiXJR/6W6bL3eyLBA4xPF3ZkZnyVh1UDd5oLT/G++cI2bami1qNSvhCn+E+AUV5XGdRow==",
       "dev": true,
       "requires": {
         "eslint": ">=5.0.0",
@@ -20620,6 +20636,16 @@
         "yargs": "^16.0.0"
       },
       "dependencies": {
+        "@financial-times/eslint-config-next": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
+          "integrity": "sha512-cOwrhMrXlCd/TiD42EQdx0s8VXiELYpSJn+mI6TZrZ0YdaRw9ykcszRRQe/HA5zN8Srr/8izJzVT1yJ0RkN1vg==",
+          "dev": true,
+          "requires": {
+            "eslint": ">=5.0.0",
+            "eslint-plugin-no-only-tests": ">=2.0.0"
+          }
+        },
         "acorn": {
           "version": "6.4.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Implementation for the syndication indicator, for users who subscribe to the new FT syndication platform",
   "devDependencies": {
     "@babel/runtime": "^7.10.2",
+    "@financial-times/eslint-config-next": "^7.0.0",
     "@financial-times/n-gage": "^9.0.1",
     "@financial-times/n-heroku-tools": "^14.0.0",
     "@financial-times/o-buttons": "^7.3.0",
@@ -63,7 +64,9 @@
     "commit": "commit-wizard",
     "test": "make test",
     "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine",
+    "lint": "eslint . --ext .jsx,.js",
+    "lint-fix": "eslint . --ext .jsx,.js --fix"
   },
   "false": {},
   "husky": {


### PR DESCRIPTION
We have a PR that is pushed without issues, but is failing on ci because it has spaces and not tabs. This repo didn't respond to `eslint . --ext .jsx,.js` - this PR fixes that. It also adds a config that relies on the next standard and a couple of npm scripts so that people can run `npm run lint-fix`. 

