### PR TITLE
Remove snyk [automated]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "postcss-loader": "^7.3.3",
         "sass-lint": "^1.13.1",
         "sass-loader": "^13.3.2",
-        "snyk": "^1.167.2",
         "style-loader": "^3.3.3",
         "webpack": "^5.89.0",
         "webpack-merge": "^5.9.0",
@@ -14665,23 +14664,6 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/snyk": {
-      "version": "1.1228.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1228.0.tgz",
-      "integrity": "sha512-DLPcGazN+F7sR8v2ABCvsSLifOLoW1Episyu4De9Ho8x+EXgX8sTlbI9LkmL5dndY7bmWxaQ6w0qsvXZQNB4dA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@sentry/node": "^7.36.0",
-        "global-agent": "^3.0.0"
-      },
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/socks": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "postcss-loader": "^7.3.3",
     "sass-lint": "^1.13.1",
     "sass-loader": "^13.3.2",
-    "snyk": "^1.167.2",
     "style-loader": "^3.3.3",
     "webpack": "^5.89.0",
     "webpack-merge": "^5.9.0",
@@ -73,7 +72,6 @@
   "scripts": {
     "commit": "commit-wizard",
     "test": "dotcom-tool-kit test:local",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
     "lint": "eslint . --ext .jsx,.js",
     "lint-fix": "eslint . --ext .jsx,.js --fix",
     "build": "dotcom-tool-kit build:local",


### PR DESCRIPTION
In mid-December 2024 we will be letting our Snyk contract expire. We'll
be moving to GitHub Advanced Security as an alternative.

This PR is an attempt to get ahead of the deadline. Considering how out
of date some of our Snyk implementations are, and that we rarely take
the time to merge the PRs, we think it's fine to remove it way ahead of
time.

If you want an interrim solution, enable Dependabot Security updates for
this repository by visiting the following page and clicking 'Enable' next
to 'Dependabot security updates':
https://github.com/Financial-Times/n-syndication/settings/security_analysis

You're also free to ignore this PR and do the work yourself closer to
the deadline. Cyber will be doing some broader comms later in the year.

This PR was automated, please take a little extra care when reviewing. I
won't be attempting to fix build failures or small repo-specific quirks
but feel free to build on top of this PR.

**Note:** we were unable to automatically update the package lock for this
repository as our script encountered errors. You may need to look into the
issue before merging.