### PR TITLE
LIF-109 Add filters to publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ workflows:
             - tool-kit/test
           context: npm-publish-token
           filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-.+)?/
             branches:
               ignore: /.*/
   nightly:


### PR DESCRIPTION
## Description
Whilst doing the toolkit migration to version 4, the tool-kit/publish-tag job got the filters.tags.only field removed. This possibly caused the publish job to not result in a new version being pushed to the npm registry. This is an attempt to fix that.

[JIRA](https://financialtimes.atlassian.net/browse/LIF-109)