### PR TITLE
LIF-109 Add filters to build and test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,16 @@ workflows:
           executor: node
           requires:
             - tool-kit/setup
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/test:
           executor: node
           requires:
             - tool-kit/build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/publish-tag:
           executor: node
           requires:


### PR DESCRIPTION
## Description
Whilst doing the toolkit migration to version 4, the some of the filters.tags.only fields got removed. This possibly caused the publish job to not result in a new version being pushed to the npm registry. This should now fully fix this.

[JIRA](https://financialtimes.atlassian.net/browse/LIF-109)