### PR TITLE
Download dialog info banner for flourish graphics articles

### DIFF
--- a/src/js/modal-download.js
+++ b/src/js/modal-download.js
@@ -131,6 +131,8 @@ function createElement (item) {
 			? 'save-for-later'
 			: 'save-for-later-downloads-page';
 		const title = overlayManager.USER_DATA.MAINTENANCE_MODE === true ? '' : item.title;
+		const enrichedContent = Boolean(overlayManager.USER_DATA?.allowed?.rich_articles && item.hasFlourishGraphics);
+
 		let downloadTrackingId;
 		let saveText;
 
@@ -149,6 +151,13 @@ function createElement (item) {
 		return toElement(`<div class="n-syndication-modal-shadow"></div>
 							<div class="n-syndication-modal n-syndication-modal-${item.type
 }" role="dialog" aria-labelledby="'Download:  ${title}" tabindex="0">
+								${enrichedContent ? `<div class="n-syndication-modal-info-bubble">
+									<span class="n-syndication-modal-info-bubble__icon"></span>
+									<div class="n-syndication-modal-info-bubble__text">
+										<span class="n-syndication-modal-info-bubble__text--emphasized">Visual content</span> 
+										<span>may not be available for download due to copyright.</span>
+									</div>
+								</div>`: ''}
 								<header class="n-syndication-modal-heading">
 									<a class="n-syndication-modal-close" data-action="close" 'data-trackable="close-syndication-modal" role="button" href="#" aria-label="Close" title="Close" tabindex="0"></a>
 									<span role="heading" class="n-syndication-modal-title">${title}</span>

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -283,6 +283,36 @@
   line-height: 20px;
 }
 
+.n-syndication-modal-info-bubble {
+	padding: var(--o3-spacing-4xs, 8px);
+	min-width: var(--o3-spacing-2xl);
+	background-color: var(--o3-color-palette-wheat);
+	color: var(--o3-color-palette-black-90);
+	position: relative;
+	display: flex;
+	font-size: 14px;
+	font-weight: var(--o3-font-weight-regular);
+	line-height: var(--o3-font-lineheight-0);
+	margin: var(--o3-spacing-s) var(--o3-spacing-xs) var(--o3-spacing-4xs);
+
+	&__icon {
+		background-image: url('https://images.ft.com/v3/image/raw/fticon-v1%3Awarning-alt?source=next-syn-list');
+		width: 20px;
+		height: 20px;
+		flex-shrink: 0;
+ 	   	fill: var(--o3-color-palette-black-90);
+	}
+
+	&__text {
+		display: inline;
+		padding-left: var(--o3-spacing-5xs);
+	}
+
+	&__text--emphasized {
+		font-weight: var(--o3-font-weight-bold);
+	}
+}
+
 .n-syndication-actions {
   text-align: right;
 }


### PR DESCRIPTION
This PR displays info banner related to flourish graphics. Banner will only be displayed for articles with flourish graphics and contracts which are allowed rich articles.

#### Ticket - https://financialtimes.atlassian.net/browse/LIF-771

#### Before -
<img width="1489" height="491" alt="Screenshot 2025-09-26 at 13 34 14" src="https://github.com/user-attachments/assets/74c1090a-d9bc-4b53-bfc2-8353584277a4" />

#### After - 
<img width="1489" height="491" alt="Screenshot 2025-09-26 at 13 30 59" src="https://github.com/user-attachments/assets/f11312ed-8fd7-41a4-b745-68707339abfb" />
